### PR TITLE
Extend DTO, prompt->messages body prop

### DIFF
--- a/src/modules/openai/openai.dto.ts
+++ b/src/modules/openai/openai.dto.ts
@@ -1,5 +1,25 @@
-import { t } from "elysia"
+import { t, type Static } from "elysia"
 
 export const chatCompletionsDTO = t.Object({
-  prompt: t.String()
+  messages: t.Array(
+    t.Object({
+      role: t.Enum(
+        {
+          user: "user",
+          assistant: "assistant"
+        },
+        {
+          examples: ["user"],
+          description:
+            "This can be either `user` or `assistant`. See the [OpenAI documentation](https://platform.openai.com/docs/api-reference/chat/create) for more information."
+        }
+      ),
+      content: t.String({
+        examples: ["This is a message"],
+        description: "Message content"
+      })
+    })
+  )
 })
+
+export type ChatCompletionsDTO = Static<typeof chatCompletionsDTO>

--- a/src/modules/openai/openai.route.ts
+++ b/src/modules/openai/openai.route.ts
@@ -6,10 +6,10 @@ import { createCompletion, createStreamCompletion } from "./openai.service"
 export const openAIRoutes = (app: Elysia) => {
   app.group("/openai", app =>
     app
-      .post("/completions", async ({ body: { prompt } }) => await createCompletion({ prompt }), {
+      .post("/completions", async ({ body: { messages } }) => await createCompletion({ messages }), {
         body: chatCompletionsDTO
       })
-      .post("/completions/stream", async ({ body: { prompt } }) => createStreamCompletion({ prompt }), {
+      .post("/completions/stream", async ({ body: { messages } }) => createStreamCompletion({ messages }), {
         body: chatCompletionsDTO
       })
   )

--- a/src/modules/openai/openai.service.ts
+++ b/src/modules/openai/openai.service.ts
@@ -1,33 +1,21 @@
 import Stream from "@elysiajs/stream"
 import { openai } from "../../lib/openai"
 
-interface CreateCompletion {
-  prompt: string
-}
+import type { ChatCompletionsDTO } from "./openai.dto"
 
-export async function createCompletion({ prompt }: CreateCompletion) {
+export async function createCompletion({ messages }: ChatCompletionsDTO) {
   return await openai.chat.completions.create({
     model: "gpt-3.5-turbo",
-    messages: [
-      {
-        role: "user",
-        content: prompt
-      }
-    ]
+    messages
   })
 }
 
-export async function createStreamCompletion({ prompt }: CreateCompletion) {
+export async function createStreamCompletion({ messages }: ChatCompletionsDTO) {
   return new Stream(
     openai.chat.completions.create({
       model: "gpt-3.5-turbo",
       stream: true,
-      messages: [
-        {
-          role: "user",
-          content: prompt
-        }
-      ]
+      messages
     })
   )
 }


### PR DESCRIPTION
- Switches body property from `prompt` to `messages` and passes it directly as array to OpenAI
- Extends the DTO to match the above change, also adds description for swagger docs.